### PR TITLE
Adding examples to GithubPages

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -5,11 +5,11 @@
 	<title>Metrics-Watcher Examples</title>
 
 	<!-- must include jquery -->
-	<script src="http://cdnjs.cloudflare.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
+	<script src="//cdnjs.cloudflare.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
 
 	<!-- must include bootstrap -->
-	<link rel="stylesheet" type="text/css" href="http://netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css">
-        <script src="http://netdna.bootstrapcdn.com/bootstrap/3.0.0/js/bootstrap.min.js"></script>
+	<link rel="stylesheet" type="text/css" href="//netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css">
+        <script src="//netdna.bootstrapcdn.com/bootstrap/3.0.0/js/bootstrap.min.js"></script>
 
 
 	<!--  And include the metrics-watcher library -->


### PR DESCRIPTION
It is rather convenient to have an examples served by GH pages directly, like this http://bzz.github.io/metrics-watcher/examples/

No need to merge this PR though, it's just an example, please consider creating gh-pages branch in your repo.